### PR TITLE
Support fixed cluster name in traits

### DIFF
--- a/src/core/src/main/scala/ecdc/core/TraitReader.scala
+++ b/src/core/src/main/scala/ecdc/core/TraitReader.scala
@@ -4,13 +4,19 @@ import java.io.File
 import java.util
 
 import com.typesafe.config.ConfigFactory
-import model.Service
+import model.{ Cluster, Service }
 import org.slf4j.LoggerFactory
+
 import scala.collection.JavaConverters._
 import scala.util.Try
 import TraitReader._
 
-case class ServiceTrait(name: String)
+trait ServiceTrait {
+  def name: String
+}
+
+case class DefaultServiceTrait(name: String) extends ServiceTrait
+case class ServiceTraitWithFixedCluster(name: String, cluster: Cluster) extends ServiceTrait
 
 case class TraitReader(service: Service, repoDir: File) {
 
@@ -21,8 +27,7 @@ case class TraitReader(service: Service, repoDir: File) {
       .parseFile(traitConf)
       .getStringList("traits")).getOrElse(new util.ArrayList())
       .asScala
-      .filter(traitDirectoryExists(_, repoDir))
-      .map(ServiceTrait)
+      .flatMap(getServiceTrait(_, repoDir))
   }
 }
 
@@ -30,11 +35,28 @@ object TraitReader {
 
   val logger = LoggerFactory.getLogger(getClass)
 
-  def traitDirectoryExists(t: String, repoDir: File): Boolean =
-    if (new File(repoDir, s"trait/$t").exists()) true
-    else {
-      logger.warn(s"Unable to read trait directory: trait/$t")
-      false
+  def getServiceTrait(t: String, repoDir: File): Option[ServiceTrait] = {
+    val serviceTrait = t.split("->", 2).toList match {
+      case n :: Nil =>
+        VariableResolver.Helper.traitDirExists(repoDir, n) match {
+          case true => Some(DefaultServiceTrait(n))
+          case false => None
+        }
+      case n :: c :: Nil =>
+        val cluster = Cluster(c)
+        VariableResolver.Helper.traitDirExists(repoDir, n, cluster) match {
+          case true => Some(ServiceTraitWithFixedCluster(n, cluster))
+          case false => None
+        }
+      case default => None
     }
 
+    serviceTrait match {
+      case None =>
+        logger.warn(s"Unable to read trait directory: $t")
+      case _ =>
+    }
+
+    serviceTrait
+  }
 }

--- a/src/core/src/test/resources/testRepo/service/with-common-trait/trait.conf
+++ b/src/core/src/test/resources/testRepo/service/with-common-trait/trait.conf
@@ -1,0 +1,3 @@
+traits = [
+  logging-common->common
+]

--- a/src/core/src/test/resources/testRepo/trait/logging-common/cluster/common/var/LOGGING_SERVICE_KEY
+++ b/src/core/src/test/resources/testRepo/trait/logging-common/cluster/common/var/LOGGING_SERVICE_KEY
@@ -1,0 +1,1 @@
+common_logging_service_key_foo

--- a/src/core/src/test/scala/ecdc/core/ServiceConfigSpec.scala
+++ b/src/core/src/test/scala/ecdc/core/ServiceConfigSpec.scala
@@ -16,7 +16,7 @@ class ServiceConfigSpec extends Spec {
 
   it should "apply traits to service.conf" in {
     val baseConf = ConfigFactory.parseFile(baseDir.toPath.resolve(s"service/${service.name}/service.conf").toFile)
-    val config = ServiceConfig.applyTraits(Seq(ServiceTrait("loadbalancer")), baseConf, baseDir, cluster)
+    val config = ServiceConfig.applyTraits(Seq(DefaultServiceTrait("loadbalancer")), baseConf, baseDir, cluster)
     config.hasPath("loadbalancer") shouldBe true
   }
 
@@ -36,7 +36,7 @@ class ServiceConfigSpec extends Spec {
   }
 
   it should "tolerate missing service.conf" in {
-    val sc = ServiceConfig.read(Service("baz"), cluster, version, baseDir, Map("MEMORY" -> "1024", "CLUSTER" -> "production"), Seq(ServiceTrait("webapp")))
+    val sc = ServiceConfig.read(Service("baz"), cluster, version, baseDir, Map("MEMORY" -> "1024", "CLUSTER" -> "production"), Seq(DefaultServiceTrait("webapp")))
     val td = sc.taskDefinition
     td.containerDefinitions.head.environment shouldBe Seq(
       Environment("MEMORY", "1024"),

--- a/src/core/src/test/scala/ecdc/core/TraitReaderSpec.scala
+++ b/src/core/src/test/scala/ecdc/core/TraitReaderSpec.scala
@@ -2,7 +2,7 @@ package ecdc.core
 
 import java.io.File
 
-import model.Service
+import model.{ Cluster, Service }
 import testutils.Spec
 
 class TraitReaderSpec extends Spec {
@@ -17,6 +17,12 @@ class TraitReaderSpec extends Spec {
   it should "ignore missing traits.conf" in {
     val traits = TraitReader(Service("bar"), baseDir).readTraits
     traits shouldBe Nil
+  }
+
+  it should "read trait with specific cluster name" in {
+    val traits = TraitReader(Service("with-common-trait"), baseDir).readTraits
+    traits should have size 1
+    traits.head shouldBe ServiceTraitWithFixedCluster("logging-common", Cluster("common"))
   }
 
 }

--- a/src/core/src/test/scala/ecdc/core/VariableResolverSpec.scala
+++ b/src/core/src/test/scala/ecdc/core/VariableResolverSpec.scala
@@ -11,7 +11,7 @@ class VariableResolverSpec extends Spec {
 
   it should "resolve variables for traits" in {
     val vars = resolveVariables(testRepo,
-      Seq(ServiceTrait("logging"), ServiceTrait("syslog")), Service("foo"), Cluster("production"))
+      Seq(DefaultServiceTrait("logging"), DefaultServiceTrait("syslog")), Service("foo"), Cluster("production"))
     vars should have size 2
     vars should contain(Variable("LOGGING_SERVICE_KEY",
       PlainValue("logging_service_key_foo"), "trait/logging/cluster/production/var"))
@@ -19,7 +19,7 @@ class VariableResolverSpec extends Spec {
 
   it should "pick service vars in favour of trait vars" in {
     val vars = resolveVariables(testRepo,
-      Seq(ServiceTrait("syslog")), Service("foo"), Cluster("production"))
+      Seq(DefaultServiceTrait("syslog")), Service("foo"), Cluster("production"))
     vars.head shouldBe Variable("SYSLOG_URL",
       PlainValue("syslog_url_foo"), "service/foo/cluster/production/var")
   }


### PR DESCRIPTION
We don't want to duplicate settings for different clusters when the settings are actually the same (e.g. logging backend). So we'd like to have the possibility to make the cluster name fixed.